### PR TITLE
Adding SSL certificates to puppet, and their automatic renewal

### DIFF
--- a/modules/jinteki/manifests/init.pp
+++ b/modules/jinteki/manifests/init.pp
@@ -12,6 +12,9 @@ class jinteki {
   include jinteki::nodejs
   include jinteki::scripts
   include jinteki::users
+  include jinteki::letsencrypt_jinteki
+  include jinteki::letsencrypt_ws
+  include jinteki::letsencrypt_renew
 
   Class[jinteki::users]
   -> Class[jinteki::iptables]
@@ -21,4 +24,7 @@ class jinteki {
   -> Class[jinteki::clojure]
   -> Class[jinteki::game]
   -> Class[jinteki::scripts]
+  -> Class[jinteki::letsencrypt_jinteki]
+  -> Class[jinteki::letsencrypt_ws]
+  -> Class[jinteki::letsencrypt_renew]
 }

--- a/modules/jinteki/manifests/letsencrypt_jinteki.pp
+++ b/modules/jinteki/manifests/letsencrypt_jinteki.pp
@@ -1,0 +1,11 @@
+class jinteki::letsencrypt_jinteki {
+  ensure_packages([
+    'certbot',
+    'certbot-nginx',
+  ])
+
+  exec { 'letsencrypt_jinteki':
+    command => "/usr/bin/certbot -n --agree-tos --redirect --nginx -d jinteki.zaroth.net --email lukasz.dobrogowski@gmail.com",
+    creates => "/etc/letsencrypt/live/jinteki.zaroth.net"
+  }
+}

--- a/modules/jinteki/manifests/letsencrypt_renew.pp
+++ b/modules/jinteki/manifests/letsencrypt_renew.pp
@@ -1,0 +1,14 @@
+class jinteki::letsencrypt_renew {
+  ensure_packages([
+    'cronie'
+  ])
+
+  cron { 'letsencrypt_jinteki_renew':
+    ensure => 'present',
+    command => "/usr/bin/certbot renew --quiet --agree-tos",
+    user => 'jinteki',
+    hour => 10,
+    minute => 42,
+  }
+
+}

--- a/modules/jinteki/manifests/letsencrypt_ws.pp
+++ b/modules/jinteki/manifests/letsencrypt_ws.pp
@@ -1,0 +1,10 @@
+class jinteki::letsencrypt_ws {
+  ensure_packages([
+    'certbot',
+    'certbot-nginx',
+  ])
+  exec { 'letsencrypt_ws':
+    command => "/usr/bin/certbot -n --agree-tos --redirect --nginx -d ws.zaroth.net --email lukasz.dobrogowski@gmail.com",
+    creates => "/etc/letsencrypt/live/ws.zaroth.net
+  }
+}

--- a/modules/jinteki/templates/nginx/nginx.conf.epp
+++ b/modules/jinteki/templates/nginx/nginx.conf.epp
@@ -16,8 +16,24 @@ http {
   charset utf-8;
 
   server {
-    listen 80 default_server;
-    server_name jinteki.zaroth.net ws.jinteki.zaroth.net ws.zaroth.net;
+    listen 80;
+    server_name ws.zaroth.net;
+    keepalive_timeout 90s;
+    location / {
+      proxy_pass http://127.0.0.1:1042;
+    }
+  }
+  server {
+    listen 80;
+    server_name ws.jinteki.zaroth.net;
+    keepalive_timeout 90s;
+    location / {
+      proxy_pass http://127.0.0.1:1042;
+    }
+  }
+  server {
+    listen 80;
+    server_name jinteki.zaroth.net;
     keepalive_timeout 90s;
     location / {
       proxy_pass http://127.0.0.1:1042;


### PR DESCRIPTION
As Let's Encrypt Doesn't offer wildcards certificates, we have to split every subdomains in vhsots in the nginx config

I added 2 Puppets files to handle 2 subdomains (jinteki.zaroth.net and ws.zaroth.net)
I made two of them because the current nginx support of certbot is limited, and calling it twice prevents problems.
I added several options to them : 
-n to prevent any GUI from appearing
--agree-tos -d jinteki.zaroth.net and --email is self explanatory
--redirect force users to use https
--nginx to tell certbot which plugin to use, 'certbot-nginx' is required to use that

The 3rd Puppet script is used to add a cron job to jinteki user to renew the certificates every day at 10:42, adding a random minute helps them to not overload their servers.

In order to deliver a certificate, Let's Encrypt will do some testing on your webserver, so they need the domain to be online during that.
